### PR TITLE
This is fine O.O

### DIFF
--- a/arenstorf.cxx
+++ b/arenstorf.cxx
@@ -1,0 +1,200 @@
+#include <iostream>
+#include <cmath>
+
+using namespace std;
+// global variables
+const double TOL = 1E-5;
+const double mu = 0.012277471;
+
+// Define functions
+void k_func(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt, double a[][7], double c[]);
+double k_x_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y);
+double k_y_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y);
+void rk_4(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt);
+void rk_5(double Y5_x[], double Y5_y[], double kx[], double ky[], double dt);
+double new_step(double Y4_x[], double Y4_y[], double Y5_x[], double Y5_y[], double dt);
+
+// Main function
+int main(){
+	double dt = 10E-5;
+	// Time variable
+	double T = 0;
+	double T_end = 18.0;
+
+	// For RK4 -> Y4 = [ y(t_n),  y'(t_n), y''(t_n) ]
+	double* Y4_x = new double [3];
+	double* Y4_y = new double [3];
+	// For RK5 -> Y5 = [ x, y, x', y']
+	double* Y5_x = new double [4];
+	// Y5_y = [ y(t_n),  y'(t_n), y''(t_n) ]
+	double* Y5_y = new double [3];
+
+    // Define the k-vector for x and y
+    double* kx = new double [7];
+    double* ky = new double [7];
+
+	// define constans for the different RK methods
+	double* c = new double [7];
+
+	// Because I alreay know the size of Matrix A
+	// I use static allocation as multidimensional Array.
+	// Only the lower diagonal matrix will be != 0.
+	// Yeah, I know we should use a long array instead a "matrix" in C++
+	// But in this case we already know the dimension.
+    double a[7][7];
+    for(int i=0 ; i<7 ; i++){
+        for(int j=0 ; j<7 ; j++)
+            a[i][j] = 0;
+    }
+	a[1][0] = 1.0/5;
+
+	a[2][0] = 3.0/40;
+	a[2][1] = 9.0/40;
+
+	a[3][0] = 44.0/45;
+	a[3][1] = -56.0/15;
+	a[3][2] = 32.0/9;
+
+	a[4][0] = 19372.0/6561;
+	a[4][1] = -25360.0/2187;
+	a[4][2] = 64448.0/6561;
+	a[4][3] = -212.0/729;
+
+	a[5][0] = 9017.0/3168;
+	a[5][1] = -355.0/33;
+	a[5][2] = 46732.0/5247;
+	a[5][3] = 49.0/176;
+	a[5][4] = -5103.0/18656;
+
+	a[6][0] = 35.0/384;
+	a[6][1] = 0;
+	a[6][2] = 500.0/1113;
+	a[6][3] = 125.0/192;
+	a[6][4] = -2187.0/6784;
+	a[6][5] = 11.0/84;
+
+	// The c-vector is for both rk methods the same
+	// Because of that, I define it one time only in the main
+	// function.
+	c[0] = 0;
+	c[1] = 1.0/5;
+	c[2] = 3.0/10;
+	c[3] = 4.0/5;
+	c[4] = 8.0/9;
+	c[5] = 1;
+	c[6] = 1;
+
+	// Initial values at T=0
+	Y4_x[0] = 0.994;
+    Y4_y[0] = 0;
+	Y4_x[1] = 0;
+    Y4_y[1] = -2.00158510637908;
+
+	Y5_x[0] = 0.994;
+	Y5_y[0] = 0;
+    Y5_x[1] = 0;
+	Y5_y[1] = -2.00158510637908;
+	cout << T << "\t" << Y4_x[0] << "\t" << Y4_y[0] << endl;
+
+	while(T < T_end){
+        // Calculate k vector
+        k_func(Y4_x, Y4_y, kx, ky, dt, a, c);
+        // Use specific weights for RK4 method
+        rk_4(Y4_x, Y4_y, kx, ky, dt);
+        // Use specific weights for RK5 method
+        rk_5(Y5_x, Y5_y, kx, ky, dt);
+        // Give out new y_n+1
+        cout << T << "\t" << Y4_x[0] << "\t" << Y4_y[0] << endl;
+        // One step more
+        T += dt;
+        dt = new_step(Y4_x, Y4_y, Y5_x, Y5_y, dt);
+	}
+	return 0;
+}
+
+void k_func(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt, double a[][7], double c[]){
+    double factor_x = 0;
+    double factor_y = 0;
+
+	for(int i=0; i<7; i++){
+		factor_x = 0;
+		factor_y = 0;
+		if (i!=0){
+            for(int j=0; j<7; j++){
+                factor_x += a[i][j]*dt*kx[i-1];
+                factor_y += a[i][j]*dt*ky[i-1];
+                //cout << "a(" << i << ";" << j << ") = " << a[i][j] << endl;
+			}
+		}
+
+		double r = sqrt(pow((Y4_x[0]+factor_x)+mu,2) + pow((Y4_y[0]+factor_y),2));
+		double s = sqrt(pow((Y4_x[0]+factor_x)-1+mu,2) + pow((Y4_y[0]+factor_y),2));
+		kx[i] = k_x_calc(Y4_x, Y4_y, r, s, factor_x, factor_y);
+		ky[i] = k_y_calc(Y4_x, Y4_y, r, s, factor_x, factor_y);
+	}
+}
+
+double k_x_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y){
+	return (Y4_x[0]+factor_x) + 2.0*(Y4_y[1]+factor_y) - (1.0-mu)*((Y4_x[0]+factor_x)+mu)/pow(r,3) - mu*((Y4_x[0]+factor_x)-1.0+mu)/pow(s,3);
+}
+
+double k_y_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y){
+	return (Y4_y[0]+factor_y) - 2.0*(Y4_x[1]+factor_x) - (1.0-mu)*(Y4_y[0]+factor_y)/pow(r,3) - (Y4_x[0]+factor_x)/pow(s,3);
+}
+
+void rk_4(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt){
+	// Define specific constant weights for rk_4
+	double* b = new double [7];
+
+	b[0] = 5179.0/57600;
+	b[1] = 0;
+	b[2] = 7571.0/16695;
+	b[3] = 393.0/640;
+	b[4] = -92097.0/339200;
+	b[5] = 187.0/2100;
+	b[6] = 1/40;
+    double tmp_x = 0;
+    double tmp_y = 0;
+	for(int i=0 ; i<7 ; i++)
+	{
+		tmp_x += b[i]*kx[i];
+		tmp_y += b[i]*ky[i];
+	}
+    Y4_x[0] += dt*tmp_x;
+	Y4_y[0] += dt*tmp_y;
+}
+
+void rk_5(double Y5_x[], double Y5_y[], double kx[], double ky[], double dt){
+	// Define specific constant weights for rk_5
+	double* b = new double [7];
+
+	b[0] = 35.0/384;
+	b[1] = 0;
+	b[2] = 500.0/1113;
+	b[3] = 125.0/192;
+	b[4] = -2187.0/6784;
+	b[5] = 11.0/84;
+	b[6] = 0;
+    double tmp_x = 0;
+    double tmp_y = 0;
+	for(int i=0 ; i<7 ; i++)
+	{
+		tmp_x += b[i]*kx[i];
+		tmp_y += b[i]*ky[i];
+	}
+	Y5_x[0] += dt*tmp_x;
+	Y5_y[0] += dt*tmp_y;
+}
+
+double new_step(double Y4_x[], double Y4_y[], double Y5_x[], double Y5_y[], double dt){
+	// Security Factor q:=0.5
+	double q = 0.5;
+	// Order of the RK method
+	int p = 4;
+	// Calculate H (local error)
+	double H = abs(Y4_x[0]-Y5_x[0]);
+	// Calculate new dt
+	dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
+	return dt;
+}
+

--- a/arenstorf.cxx
+++ b/arenstorf.cxx
@@ -7,194 +7,184 @@ const double TOL = 1E-5;
 const double mu = 0.012277471;
 
 // Define functions
-void k_func(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt, double a[][7], double c[]);
-double k_x_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y);
-double k_y_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y);
-void rk_4(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt);
-void rk_5(double Y5_x[], double Y5_y[], double kx[], double ky[], double dt);
-double new_step(double Y4_x[], double Y4_y[], double Y5_x[], double Y5_y[], double dt);
+void k_func(double Y4[], double k[][4], double dt, const double a[][7]);
+double k_2_calc(double k_vec, double x1, double x2,double x4, double r, double s);
+double k_3_calc(double k_vec, double x1, double x2,double x3, double r, double s);
+
+void rk_4(double Y4[], double k[][4], double dt, double b4[]);
+void rk_5(double Y5[], double k[][4], double dt, double b5[]);
+
+double new_step(double Y4[], double Y5[], double dt);
 
 // Main function
 int main(){
-	double dt = 10E-5;
+	double dt = 1E-4;
 	// Time variable
 	double T = 0;
 	double T_end = 18.0;
 
-	// For RK4 -> Y4 = [ y(t_n),  y'(t_n), y''(t_n) ]
-	double* Y4_x = new double [3];
-	double* Y4_y = new double [3];
+	// For RK4 -> Y4 = [ x, y, x', y']
+	double* Y4 = new double [4];
+
 	// For RK5 -> Y5 = [ x, y, x', y']
-	double* Y5_x = new double [4];
-	// Y5_y = [ y(t_n),  y'(t_n), y''(t_n) ]
-	double* Y5_y = new double [3];
+	double* Y5 = new double [4];
 
-    // Define the k-vector for x and y
-    double* kx = new double [7];
-    double* ky = new double [7];
-
-	// define constans for the different RK methods
-	double* c = new double [7];
+    double k[7][4] = { 0 };
 
 	// Because I alreay know the size of Matrix A
 	// I use static allocation as multidimensional Array.
 	// Only the lower diagonal matrix will be != 0.
 	// Yeah, I know we should use a long array instead a "matrix" in C++
 	// But in this case we already know the dimension.
-    double a[7][7];
-    for(int i=0 ; i<7 ; i++){
-        for(int j=0 ; j<7 ; j++)
-            a[i][j] = 0;
-    }
-	a[1][0] = 1.0/5;
+    const double a[7][7] =
+    {
+    { 0,            0,              0,              0,          0,              0,       0 },
+    { 1.0/5,        0,              0,              0,          0,              0,       0 },
+    { 3.0/40,       9.0/40,         0,              0,          0,              0,       0 },
+    { 44.0/45,      -56.0/15,       32.0/9,         0,          0,              0,       0 },
+    { 19372.0/6561, -25360.0/2187,  64448.0/6561,   -212.0/729, 0,              0,       0 },
+    { 9017.0/3168,  -355.0/33,      46732.0/5247,   49.0/176,   -5103.0/18656,  0,       0 },
+    { 35.0/384,     0,              500.0/1113,     125.0/192,  -2187.0/6784,   11.0/84, 0 }
+    };
 
-	a[2][0] = 3.0/40;
-	a[2][1] = 9.0/40;
+    double b4[7] =
+    {
+    5179.0/57600,
+	0,
+	7571.0/16695,
+	393.0/640,
+	-92097.0/339200,
+	187.0/2100,
+	1.0/40
+	};
 
-	a[3][0] = 44.0/45;
-	a[3][1] = -56.0/15;
-	a[3][2] = 32.0/9;
-
-	a[4][0] = 19372.0/6561;
-	a[4][1] = -25360.0/2187;
-	a[4][2] = 64448.0/6561;
-	a[4][3] = -212.0/729;
-
-	a[5][0] = 9017.0/3168;
-	a[5][1] = -355.0/33;
-	a[5][2] = 46732.0/5247;
-	a[5][3] = 49.0/176;
-	a[5][4] = -5103.0/18656;
-
-	a[6][0] = 35.0/384;
-	a[6][1] = 0;
-	a[6][2] = 500.0/1113;
-	a[6][3] = 125.0/192;
-	a[6][4] = -2187.0/6784;
-	a[6][5] = 11.0/84;
+    double b5[7] =
+    {
+    35.0/384,
+	0,
+	500.0/1113,
+	125.0/192,
+	-2187.0/6784,
+	11.0/84,
+	0
+	};
 
 	// The c-vector is for both rk methods the same
 	// Because of that, I define it one time only in the main
 	// function.
-	c[0] = 0;
-	c[1] = 1.0/5;
-	c[2] = 3.0/10;
-	c[3] = 4.0/5;
-	c[4] = 8.0/9;
-	c[5] = 1;
-	c[6] = 1;
+	//const double c[7] = {0, 1.0/5,  3.0/10, 4.0/5,  8.0/9,  1,  1 };
 
 	// Initial values at T=0
-	Y4_x[0] = 0.994;
-    Y4_y[0] = 0;
-	Y4_x[1] = 0;
-    Y4_y[1] = -2.00158510637908;
+	Y4[0] = 0.994;
+    Y4[1] = 0;
+	Y4[2] = 0;
+    Y4[3] = -2.00158510637908;
 
-	Y5_x[0] = 0.994;
-	Y5_y[0] = 0;
-    Y5_x[1] = 0;
-	Y5_y[1] = -2.00158510637908;
-	cout << T << "\t" << Y4_x[0] << "\t" << Y4_y[0] << endl;
+	Y5[0] = 0.994;
+	Y5[1] = 0;
+    Y5[2] = 0;
+	Y5[3] = -2.00158510637908;
+	//cout << T << "\t" << Y4[0] << "\t" << Y4[1] << endl;
 
 	while(T < T_end){
-        // Calculate k vector
-        k_func(Y4_x, Y4_y, kx, ky, dt, a, c);
-        // Use specific weights for RK4 method
-        rk_4(Y4_x, Y4_y, kx, ky, dt);
-        // Use specific weights for RK5 method
-        rk_5(Y5_x, Y5_y, kx, ky, dt);
         // Give out new y_n+1
-        cout << T << "\t" << Y4_x[0] << "\t" << Y4_y[0] << endl;
-        // One step more
+        cout << T << "\t" << Y4[0] << "\t" << Y4[1] << endl;
+        // Calculate k vectors
+        k_func(Y4, k, dt, a);
+        // Use specific weights for RK4 method
+        rk_4(Y4, k, dt, b4);
+        // Use specific weights for RK5 method
+        //rk_5(Y5, k, dt, b5);
+
+        // One more step
         T += dt;
-        dt = new_step(Y4_x, Y4_y, Y5_x, Y5_y, dt);
+        //dt = new_step(Y4, Y5, dt);
+        //for(int l=0 ; l<4 ; l++)
+            //Y5[l] = Y4[l];
 	}
 	return 0;
 }
 
-void k_func(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt, double a[][7], double c[]){
-    double factor_x = 0;
-    double factor_y = 0;
+void k_func(double Y4[], double k[][4], double dt, const double a[][7]){
+    // Saves temporal data
+    double tmp[4];
+    double r, s, x1, x2;
 
-	for(int i=0; i<7; i++){
-		factor_x = 0;
-		factor_y = 0;
-		if (i!=0){
-            for(int j=0; j<7; j++){
-                factor_x += a[i][j]*dt*kx[i-1];
-                factor_y += a[i][j]*dt*ky[i-1];
-                //cout << "a(" << i << ";" << j << ") = " << a[i][j] << endl;
-			}
-		}
-
-		double r = sqrt(pow((Y4_x[0]+factor_x)+mu,2) + pow((Y4_y[0]+factor_y),2));
-		double s = sqrt(pow((Y4_x[0]+factor_x)-1+mu,2) + pow((Y4_y[0]+factor_y),2));
-		kx[i] = k_x_calc(Y4_x, Y4_y, r, s, factor_x, factor_y);
-		ky[i] = k_y_calc(Y4_x, Y4_y, r, s, factor_x, factor_y);
+	for(int i=0; i<7; i++)
+	{
+        for(int l=0; l<4; l++)
+            tmp[l] = 0;
+        for(int j=0; j<i; j++)
+        {
+            for(int l=0; l<4; l++)
+                tmp[l] += a[i][j]*k[j][l];
+        }
+    x1 = Y4[0]+dt*tmp[0];
+    x2 = Y4[1]+dt*tmp[1];
+    r = sqrt(pow(x1+mu,2)+pow(x2,2));
+    s = sqrt(pow(x1-1+mu,2)+pow(x2,2));
+    k[i][0] = Y4[2]+dt*tmp[2];
+    k[i][1] = Y4[3]+dt*tmp[3];
+    k[i][2] = k_2_calc(k[i][2], x1, x2, Y4[3]+dt*tmp[3], r, s);
+    k[i][3] = k_3_calc(k[i][3], x1, x2, Y4[2]+dt*tmp[2], r, s);
+    //cout << k[i][0] << "\t" << k[i][1] << "\t" << k[i][2] << "\t" << k[i][3] << endl;
 	}
 }
 
-double k_x_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y){
-	return (Y4_x[0]+factor_x) + 2.0*(Y4_y[1]+factor_y) - (1.0-mu)*((Y4_x[0]+factor_x)+mu)/pow(r,3) - mu*((Y4_x[0]+factor_x)-1.0+mu)/pow(s,3);
+double k_2_calc(double k_vec, double x1, double x2,double x4, double r, double s){
+	k_vec = x1 + 2.0*x4 - ((1.0-mu)*(x1+mu)/pow(r,3))   - (mu*(x1-1+mu)/pow(s,3));
+	return k_vec;
 }
 
-double k_y_calc(double Y4_x[], double Y4_y[], double r, double s, double factor_x, double factor_y){
-	return (Y4_y[0]+factor_y) - 2.0*(Y4_x[1]+factor_x) - (1.0-mu)*(Y4_y[0]+factor_y)/pow(r,3) - (Y4_x[0]+factor_x)/pow(s,3);
+double k_3_calc(double k_vec, double x1, double x2, double x3, double r, double s){
+	k_vec = x2 - 2.0*x3 - ((1.0-mu)*x2/pow(r,3))        - (mu*x2/pow(s,3));
+	return k_vec;
 }
 
-void rk_4(double Y4_x[], double Y4_y[], double kx[], double ky[], double dt){
-	// Define specific constant weights for rk_4
-	double* b = new double [7];
+void rk_4(double Y4[], double k[][4], double dt, double b4[]){
+    double tmp[4] = { 0 };
 
-	b[0] = 5179.0/57600;
-	b[1] = 0;
-	b[2] = 7571.0/16695;
-	b[3] = 393.0/640;
-	b[4] = -92097.0/339200;
-	b[5] = 187.0/2100;
-	b[6] = 1/40;
-    double tmp_x = 0;
-    double tmp_y = 0;
 	for(int i=0 ; i<7 ; i++)
 	{
-		tmp_x += b[i]*kx[i];
-		tmp_y += b[i]*ky[i];
+        for(int l=0 ; l<4 ; l++)
+            tmp[l] += b4[i]*k[i][l];
 	}
-    Y4_x[0] += dt*tmp_x;
-	Y4_y[0] += dt*tmp_y;
+
+	for(int l=0 ; l<4 ; l++)
+        Y4[l] += dt*tmp[l];
 }
 
-void rk_5(double Y5_x[], double Y5_y[], double kx[], double ky[], double dt){
-	// Define specific constant weights for rk_5
-	double* b = new double [7];
+void rk_5(double Y5[], double k[][4], double dt, double b5[]){
+    double tmp[4] = { 0 };
 
-	b[0] = 35.0/384;
-	b[1] = 0;
-	b[2] = 500.0/1113;
-	b[3] = 125.0/192;
-	b[4] = -2187.0/6784;
-	b[5] = 11.0/84;
-	b[6] = 0;
-    double tmp_x = 0;
-    double tmp_y = 0;
 	for(int i=0 ; i<7 ; i++)
 	{
-		tmp_x += b[i]*kx[i];
-		tmp_y += b[i]*ky[i];
+        for(int l=0 ; l<4 ; l++)
+            tmp[l] += b5[i]*k[i][l];
 	}
-	Y5_x[0] += dt*tmp_x;
-	Y5_y[0] += dt*tmp_y;
+
+	for(int l=0 ; l<4 ; l++)
+        Y5[l] += dt*tmp[l];
 }
 
-double new_step(double Y4_x[], double Y4_y[], double Y5_x[], double Y5_y[], double dt){
+double new_step(double Y4[], double Y5[], double dt){
 	// Security Factor q:=0.5
 	double q = 0.5;
 	// Order of the RK method
 	int p = 4;
 	// Calculate H (local error)
-	double H = abs(Y4_x[0]-Y5_x[0]);
+	double H = max(
+        abs(Y4[0]-Y5[0]),
+        abs(Y4[1]-Y5[1]));
+    H = max(
+        H,
+        abs(Y4[2]-Y5[2]));
+    H = max(
+        H,
+        abs(Y4[3]-Y5[3]));
+
 	// Calculate new dt
-	dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
+	//dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
+	dt = 1E-5;
 	return dt;
 }
-

--- a/arenstorf2.cxx
+++ b/arenstorf2.cxx
@@ -98,8 +98,9 @@ void k_func(double Y4[], double k[][7], double dt, double a[][7], double c[]){
         tmp_1 += a[i][j]*k[i-1][1];
         tmp_2 += a[i][j]*k[i-1][2];
         tmp_3 += a[i][j]*k[i-1][3];
-        // cout << "a(" << i << ";" << j << ")*k[" << i-1 << "]" << a[i][j] << endl;
+        //cout << "a(" << i << ";" << j << ")*k[" << i-1 << "] ";
     }
+    //cout << endl;
     k[i][0] = k_0_calc(k[i][0], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
     k[i][1] = k_1_calc(k[i][1], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
     k[i][2] = k_2_calc(k[i][2], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
@@ -158,7 +159,7 @@ void rk_4(double Y4[], double k[][7], double dt){
 	Y4[1] += dt*tmp_1;
     Y4[2] += dt*tmp_2;
 	Y4[3] += dt*tmp_3;
-	cout << Y4[0] << "\t" << Y4[1] << "\t" << Y4[2] << "\t" << Y4[3] << endl;
+	//cout << Y4[0] << "\t" << Y4[1] << "\t" << Y4[2] << "\t" << Y4[3] << endl;
 }
 
 void rk_5(double Y5[], double k[][7], double dt){

--- a/arenstorf2.cxx
+++ b/arenstorf2.cxx
@@ -1,0 +1,236 @@
+#include <iostream>
+#include <cmath>
+
+using namespace std;
+// global variables
+const double TOL = 1E-5;
+const double mu = 0.012277471;
+
+// Define functions
+void k_func(double Y4[], double k[][7], double dt, double a[][7], double c[]);
+double k_0_calc(double k_vec, double x1, double x2,double x3,double x4);
+double k_1_calc(double k_vec, double x1, double x2,double x3,double x4);
+double k_2_calc(double k_vec, double x1, double x2,double x3,double x4);
+double k_3_calc(double k_vec, double x1, double x2,double x3,double x4);
+void rk_4(double Y4[], double k[][7], double dt);
+void rk_5(double Y5[], double k[][7], double dt);
+double new_step(double Y4[], double Y5[], double dt);
+
+// Main function
+int main(){
+	double dt = 10E-5;
+	// Time variable
+	double T = 0;
+	double T_end = 12.0;
+
+	// For RK4 -> Y4 = [ x, y, x', y']
+	double* Y4 = new double [4];
+
+	// For RK5 -> Y5 = [ x, y, x', y']
+	double* Y5 = new double [4];
+    double k[4][7];
+
+	// define constans for the different RK methods
+	double* c = new double [7];
+
+	// Because I alreay know the size of Matrix A
+	// I use static allocation as multidimensional Array.
+	// Only the lower diagonal matrix will be != 0.
+	// Yeah, I know we should use a long array instead a "matrix" in C++
+	// But in this case we already know the dimension.
+    double a[7][7];
+//    for(int i=0 ; i<7 ; i++){
+//        for(int j=0 ; j<7 ; j++)
+//            a[i][j] = 0;
+//    }
+	a[1][0] = 1.0/5;
+
+	a[2][0] = 3.0/40;
+	a[2][1] = 9.0/40;
+
+	a[3][0] = 44.0/45;
+	a[3][1] = -56.0/15;
+	a[3][2] = 32.0/9;
+
+	a[4][0] = 19372.0/6561;
+	a[4][1] = -25360.0/2187;
+	a[4][2] = 64448.0/6561;
+	a[4][3] = -212.0/729;
+
+	a[5][0] = 9017.0/3168;
+	a[5][1] = -355.0/33;
+	a[5][2] = 46732.0/5247;
+	a[5][3] = 49.0/176;
+	a[5][4] = -5103.0/18656;
+
+	a[6][0] = 35.0/384;
+	a[6][1] = 0;
+	a[6][2] = 500.0/1113;
+	a[6][3] = 125.0/192;
+	a[6][4] = -2187.0/6784;
+	a[6][5] = 11.0/84;
+
+	// The c-vector is for both rk methods the same
+	// Because of that, I define it one time only in the main
+	// function.
+	c[0] = 0;
+	c[1] = 1.0/5;
+	c[2] = 3.0/10;
+	c[3] = 4.0/5;
+	c[4] = 8.0/9;
+	c[5] = 1;
+	c[6] = 1;
+
+	// Initial values at T=0
+	Y4[0] = 0.994;
+    Y4[1] = 0;
+	Y4[2] = 0;
+    Y4[3] = -2.00158510637908;
+
+	Y5[0] = 0.994;
+	Y5[1] = 0;
+    Y5[2] = 0;
+	Y5[3] = -2.00158510637908;
+	cout << T << "\t" << Y4[0] << "\t" << Y4[1] << endl;
+
+	while(T < T_end){
+        // Calculate k vectors
+        k_func(Y4, k, dt, a, c);
+        // Use specific weights for RK4 method
+        rk_4(Y4, k, dt);
+        // Use specific weights for RK5 method
+        rk_5(Y5, k, dt);
+        // Give out new y_n+1
+        cout << T << "\t" << Y4[0] << "\t" << Y4[1] << endl;
+        // One step more
+        T += dt;
+        dt = new_step(Y4, Y5, dt);
+	}
+	return 0;
+}
+
+void k_func(double Y4[], double k[][7], double dt, double a[][7], double c[]){
+    double tmp_0, tmp_1, tmp_2, tmp_3;
+
+	for(int i=0; i<7; i++){
+    tmp_0 = 0;
+    tmp_1 = 0;
+    tmp_2 = 0;
+    tmp_3 = 0;
+    for(int j=0; j<i; j++){
+        tmp_0 += a[i][j]*k[i-1][0];
+        tmp_1 += a[i][j]*k[i-1][1];
+        tmp_2 += a[i][j]*k[i-1][2];
+        tmp_3 += a[i][j]*k[i-1][3];
+        // cout << "a(" << i << ";" << j << ")*k[" << i-1 << "]" << a[i][j] << endl;
+    }
+    k[i][0] = k_0_calc(k[i][0], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
+    k[i][1] = k_1_calc(k[i][1], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
+    k[i][2] = k_2_calc(k[i][2], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
+    k[i][3] = k_3_calc(k[i][3], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
+    //cout << k[i][0] << "\t" << k[i][1] << "\t" << k[i][2] << "\t" << k[i][3] << endl;
+	}
+}
+
+double k_0_calc(double k_vec, double x1, double x2,double x3,double x4){
+	k_vec = x3;
+	return k_vec;
+}
+
+double k_1_calc(double k_vec, double x1, double x2,double x3,double x4){
+	k_vec = x4;
+	return k_vec;
+}
+
+double k_2_calc(double k_vec, double x1, double x2,double x3,double x4){
+    double r = sqrt(pow(x1+mu,2)+pow(x2,2));
+    double s = sqrt(pow(x1-1+mu,2)+pow(x2,2));
+	k_vec = x1 + 2.0*x4 - (1.0-mu)*(x1+mu)/pow(r,3)  - mu*(x1-1.0+mu)/pow(s,3);
+	return k_vec;
+}
+
+double k_3_calc(double k_vec, double x1, double x2,double x3,double x4){
+    double r = sqrt(pow(x1+mu,2)+pow(x2,2));
+    double s = sqrt(pow(x1-1+mu,2)+pow(x2,2));
+	k_vec = x2 - 2.0*x3 - (1.0-mu)*x2/pow(r,3)       - mu*x2/pow(s,3);
+	return k_vec;
+}
+
+void rk_4(double Y4[], double k[][7], double dt){
+	// Define specific constant weights for rk_4
+	double* b = new double [7];
+
+	b[0] = 5179.0/57600;
+	b[1] = 0;
+	b[2] = 7571.0/16695;
+	b[3] = 393.0/640;
+	b[4] = -92097.0/339200;
+	b[5] = 187.0/2100;
+	b[6] = 1.0/40;
+    double tmp_0 = 0;
+    double tmp_1 = 0;
+    double tmp_2 = 0;
+    double tmp_3 = 0;
+	for(int i=0 ; i<7 ; i++)
+	{
+		tmp_0 += b[i]*k[0][i];
+		tmp_1 += b[i]*k[1][i];
+		tmp_2 += b[i]*k[2][i];
+		tmp_3 += b[i]*k[3][i];
+	}
+    Y4[0] += dt*tmp_0;
+	Y4[1] += dt*tmp_1;
+    Y4[2] += dt*tmp_2;
+	Y4[3] += dt*tmp_3;
+}
+
+void rk_5(double Y5[], double k[][7], double dt){
+	// Define specific constant weights for rk_5
+	double* b = new double [7];
+
+	b[0] = 35.0/384;
+	b[1] = 0;
+	b[2] = 500.0/1113;
+	b[3] = 125.0/192;
+	b[4] = -2187.0/6784;
+	b[5] = 11.0/84;
+	b[6] = 0;
+    double tmp_0 = 0;
+    double tmp_1 = 0;
+    double tmp_2 = 0;
+    double tmp_3 = 0;
+
+	for(int i=0 ; i<7 ; i++)
+	{
+		tmp_0 += b[i]*k[0][i];
+		tmp_1 += b[i]*k[1][i];
+		tmp_2 += b[i]*k[2][i];
+		tmp_3 += b[i]*k[3][i];
+	}
+    Y5[0] += dt*tmp_0;
+	Y5[1] += dt*tmp_1;
+    Y5[2] += dt*tmp_2;
+	Y5[3] += dt*tmp_3;
+}
+
+double new_step(double Y4[], double Y5[], double dt){
+	// Security Factor q:=0.5
+	double q = 0.5;
+	// Order of the RK method
+	int p = 4;
+	// Calculate H (local error)
+	double H = max(
+        abs(Y4[0]-Y5[0]),
+        abs(Y4[1]-Y5[1]));
+    H = max(
+        H,
+        abs(Y4[2]-Y5[2]));
+    H = max(
+        H,
+        abs(Y4[3]-Y5[3]));
+
+	// Calculate new dt
+	dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
+	//dt = 10E-5;
+	return dt;
+}

--- a/arenstorf2.cxx
+++ b/arenstorf2.cxx
@@ -18,7 +18,7 @@ double new_step(double Y4[], double Y5[], double dt);
 
 // Main function
 int main(){
-	double dt = 10E-5;
+	double dt = 1E-5;
 	// Time variable
 	double T = 0;
 	double T_end = 12.0;
@@ -28,7 +28,7 @@ int main(){
 
 	// For RK5 -> Y5 = [ x, y, x', y']
 	double* Y5 = new double [4];
-	
+
     double k[4][7];
 
 	// Because I alreay know the size of Matrix A
@@ -41,7 +41,7 @@ int main(){
     { 0,            0,              0,              0,          0,              0,       0 },
     { 1.0/5,        0,              0,              0,          0,              0,       0 },
     { 3.0/40,       9.0/40,         0,              0,          0,              0,       0 },
-    { 44.0/45,      -56/15,         32.0/9,         0,          0,              0,       0 },
+    { 44.0/45,      -56.0/15,       32.0/9,         0,          0,              0,       0 },
     { 19372.0/6561, -25360.0/2187,  64448.0/6561,   -212.0/729, 0,              0,       0 },
     { 9017.0/3168,  -355.0/33,      46732.0/5247,   49.0/176,   -5103.0/18656,  0,       0 },
     { 35.0/384,     0,              500.0/1113,     125.0/192,  -2187.0/6784,   11.0/84, 0 }
@@ -104,7 +104,7 @@ void k_func(double Y4[], double k[][7], double dt, double a[][7], double c[]){
     k[i][1] = k_1_calc(k[i][1], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
     k[i][2] = k_2_calc(k[i][2], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
     k[i][3] = k_3_calc(k[i][3], Y4[0]+dt*tmp_0, Y4[1]+dt*tmp_1, Y4[2]+dt*tmp_2, Y4[3]+dt*tmp_3);
-    //cout << k[i][0] << "\t" << k[i][1] << "\t" << k[i][2] << "\t" << k[i][3] << endl;
+    cout << k[i][0] << "\t" << k[i][1] << "\t" << k[i][2] << "\t" << k[i][3] << endl;
 	}
 }
 
@@ -158,6 +158,7 @@ void rk_4(double Y4[], double k[][7], double dt){
 	Y4[1] += dt*tmp_1;
     Y4[2] += dt*tmp_2;
 	Y4[3] += dt*tmp_3;
+	cout << Y4[0] << "\t" << Y4[1] << "\t" << Y4[2] << "\t" << Y4[3] << endl;
 }
 
 void rk_5(double Y5[], double k[][7], double dt){
@@ -207,6 +208,6 @@ double new_step(double Y4[], double Y5[], double dt){
 
 	// Calculate new dt
 	//dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
-	dt = 10E-5;
+	dt = 1E-5;
 	return dt;
 }

--- a/arenstorf2.cxx
+++ b/arenstorf2.cxx
@@ -28,58 +28,29 @@ int main(){
 
 	// For RK5 -> Y5 = [ x, y, x', y']
 	double* Y5 = new double [4];
+	
     double k[4][7];
-
-	// define constans for the different RK methods
-	double* c = new double [7];
 
 	// Because I alreay know the size of Matrix A
 	// I use static allocation as multidimensional Array.
 	// Only the lower diagonal matrix will be != 0.
 	// Yeah, I know we should use a long array instead a "matrix" in C++
 	// But in this case we already know the dimension.
-    double a[7][7];
-//    for(int i=0 ; i<7 ; i++){
-//        for(int j=0 ; j<7 ; j++)
-//            a[i][j] = 0;
-//    }
-	a[1][0] = 1.0/5;
-
-	a[2][0] = 3.0/40;
-	a[2][1] = 9.0/40;
-
-	a[3][0] = 44.0/45;
-	a[3][1] = -56.0/15;
-	a[3][2] = 32.0/9;
-
-	a[4][0] = 19372.0/6561;
-	a[4][1] = -25360.0/2187;
-	a[4][2] = 64448.0/6561;
-	a[4][3] = -212.0/729;
-
-	a[5][0] = 9017.0/3168;
-	a[5][1] = -355.0/33;
-	a[5][2] = 46732.0/5247;
-	a[5][3] = 49.0/176;
-	a[5][4] = -5103.0/18656;
-
-	a[6][0] = 35.0/384;
-	a[6][1] = 0;
-	a[6][2] = 500.0/1113;
-	a[6][3] = 125.0/192;
-	a[6][4] = -2187.0/6784;
-	a[6][5] = 11.0/84;
+    double a[7][7] =
+    {
+    { 0,            0,              0,              0,          0,              0,       0 },
+    { 1.0/5,        0,              0,              0,          0,              0,       0 },
+    { 3.0/40,       9.0/40,         0,              0,          0,              0,       0 },
+    { 44.0/45,      -56/15,         32.0/9,         0,          0,              0,       0 },
+    { 19372.0/6561, -25360.0/2187,  64448.0/6561,   -212.0/729, 0,              0,       0 },
+    { 9017.0/3168,  -355.0/33,      46732.0/5247,   49.0/176,   -5103.0/18656,  0,       0 },
+    { 35.0/384,     0,              500.0/1113,     125.0/192,  -2187.0/6784,   11.0/84, 0 }
+    };
 
 	// The c-vector is for both rk methods the same
 	// Because of that, I define it one time only in the main
 	// function.
-	c[0] = 0;
-	c[1] = 1.0/5;
-	c[2] = 3.0/10;
-	c[3] = 4.0/5;
-	c[4] = 8.0/9;
-	c[5] = 1;
-	c[6] = 1;
+	double c[7] = {0, 1.0/5,  3.0/10, 4.0/5,  8.0/9,  1,  1 };
 
 	// Initial values at T=0
 	Y4[0] = 0.994;
@@ -102,9 +73,14 @@ int main(){
         rk_5(Y5, k, dt);
         // Give out new y_n+1
         cout << T << "\t" << Y4[0] << "\t" << Y4[1] << endl;
+        //cout << T << "\t" << Y5[0] << "\t" << Y5[1] << endl;
         // One step more
         T += dt;
         dt = new_step(Y4, Y5, dt);
+        Y5[0] = Y4[0];
+        Y5[1] = Y4[1];
+        Y5[2] = Y4[2];
+        Y5[3] = Y4[3];
 	}
 	return 0;
 }
@@ -230,7 +206,7 @@ double new_step(double Y4[], double Y5[], double dt){
         abs(Y4[3]-Y5[3]));
 
 	// Calculate new dt
-	dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
-	//dt = 10E-5;
+	//dt = dt*q*pow( (TOL/H) , (1.0/(p+1)) );
+	dt = 10E-5;
 	return dt;
 }


### PR DESCRIPTION
![image](http://i.imgur.com/cTtZzxN.jpg)

So, nabend zusammen, gibt einiges zu berichten:
Aber zuerst, die Animationen ;)
![image](http://i.imgur.com/Kf5cP10.gif)
![image](http://i.imgur.com/Vhu9Ia2.gif)

Nachdem, ich anfangs vier Arrays mit jeweils 2 Einträgen definiert hatte, entschied ich mich nacher 2 Arrays mit jeweil vier Einträgen zu definieren. Jedes Array speicherte dann die Werte (x, y, x', y') für die jeweilige RK-Methode. Jedoch funktionierte mein Programm immer noch nicht, ich musste es also wohl oder übel debuggen. Da die Fragestellung leider ein paar Kontrollwerte vermissen ließ (:wink:), musste ich mir die von anderen Leuten wohl oder übel besorgen.

Da @NOP-slide zuerst die halbe Lineare Algebra definierte, fiel wohl sein Programmcode raus. Der Quellcode von @Arzneimittel entsprach schon eher meiner Struktur, auch wenn ich persönlich die Initialisierung der A-Matrix und der k-Vektoren eher unübersichtlich fand. (Außerdem waren da ein paar unnötige Schleifen drin, aber ich bin ja nicht zum meckern hier :stuck_out_tongue:)

Zum debuggen habe ich Code::Blocks verwendet und den Quellcode mit einigen cout's gespickt. Hierbei ist übrigens zu beachten, dass es nicht genügt, in C::B eine leere Datei reinzukopieren. Dann verweigert das Programm das debuggen (ohne natürlich einen Hinweis zu geben warum es das nicht debuggen kann). Man muss erst ein leeres Projekt anlegen, und dann erst den Quellcode reinkopieren. Des Weiteren ist es auch hilfreich, wenn man die "Watches" aktiviert, womit man zumindest einfache int/double Variablen nachverfolgen kann. (Bei arrays zeigt er leider nur den Pointer an, jedoch hatte ich keine Lust jedes mal einen Memory Dump zu machen :frowning:)

Da mein Programm noch nicht lief, habe ich mir die Zwischenergebnisse über cout angeschaut und mit meinen Zwischenergebnissen verglichen. Hier fiel mir auf, dass bis zum k3 Vektor alles bis zur letzten Nachkommastelle übereinstimmte. Bei dem vierten k Vektor gab es jedoch eine sehr kleine Abweichung. Das könnte man erst vernachlässigen, jedoch ist zu beachten das der aktuelle k-Vektor von allen vorherigen k-Vektoren abhängt. Auch macht man diese Zwischenschritte bei jedem vollen Schritt. Und es kommen, je nach Toleranz, mehrere Tausend volle Schritte zusammen!

![image](http://i.imgur.com/NcTCDI4.png)

Daher ging es daran, zu erkunden warum ich denn dort einen leicht anderen Wert rausbekomme. Die Funktionen, die den k-Vektor berechnen, konnten eigentlich nicht betroffen sein, da die ersten Zwischenwerte perfekt berechnet wurden. Es musste also an den Faktor liegen, der zu den Y4[i] Wert hinzu addiert wird. Der Faktor hängt von dt ab (ließ ich die gesamte zeit über in beiden Programmen konstant, um die Ergebnisse besser vergleichen zu können), fiel also raus. Des Weiteren von den vorherigen k-Vektoren (Waren ja alle korrekt) und der A-matrix.

Hier lag der Hase im Pfeffer
![iamge](http://i.imgur.com/CaDgRaA.jpg)
Den Wert  15/40
hatte ich 15/40 statt 15.0/40 geschrieben. Dadurch wurde der Bruch nicht korrekt durchgeführt.

Nachdem ich das korrigiert hatte, lief mein Programm jedoch immer noch nicht :frowning:

Den k-Vektor hatte ich als static multidimensional array definiert (Da die Maße ja bekannt sind kann man das ja machen), jedoch als double k[4][7].

Nacher habe ich aber in einem loop per
```C
k[i][0] = ...
k[i][1] = ...
k[i][2] = ...
k[i][3] = ...
```
darauf zugegriffen. Die Dimensionen waren vertauscht, aber C++ fühlte sich natürlich nicht in der Lage, mal einen Speicherzugriffsfehler rauszuhauen o.ä.

Nachdem das auch repariert wurde, habe ich mich daran gesetzt, den recht langen Code (siehe arenstorf2.cxx) kompakter und eleganter hinzuschreiben. Hierfür wurden einige Zeilen entfern dank verschiedener for-Schleifen. Als grundsätzliches Merkmal habe ich die Variable l=0,...,3 genommen, um durch die 4 Werte der jeweiligen Arrays zu schleifen. 

Hervorheben möchte ich die gute Implementierung der Matrix A (Github zerschießt ein wenig die Formatierung, wenn man das alte Dokument mit dem neuen Dokument daneben hat). Wenn man oben rechts auf "View" geht, gibt es keine Zeilenumbrüche.

Diese Optimierungen habe ich letztendlich in die Datei "arenstorf.cxx" geschrieben. Nach meinen anfänglichen Testen mit festem dt von 1e-4, das immerhin knapp 5 MB große Textdateien produzierte, konnte ich durch das dynamische dt (siehe Animation oben), eine Textdatei mit 7,7 KB produzieren.

Ich bedanke mich für die Aufmerksamkeit, und verbleibe mit:
![image](http://i.imgur.com/VzFbLkd.jpg)